### PR TITLE
Remove reference to non-existent rml file

### DIFF
--- a/l10n_se/account_report.xml
+++ b/l10n_se/account_report.xml
@@ -3,17 +3,6 @@
     <data>
         <report
             auto="False"
-            id="account_invoicesII"
-            model="account.invoice"
-            name="account.invoice"
-            rml="l10n_se/report/account_print_invoice.rml"
-            string="Invoices"
-            attachment="(object.state in ('open','paid')) and ('INV'+(object.number or '').replace('/','')+'.pdf')"
-            usage="default"
-            multi="True"/>
-
-        <report
-            auto="False"
             id="account_vat_declarationII"
             menu="True"
             model="account.tax.code"


### PR DESCRIPTION
Removed the reference to "l10n_se/report/account_print_invoice.rml" because the file doesn't exist.