### PR TITLE
[FIX] Make l10n_se install again

### DIFF
--- a/l10n_se/data/account_chart_template_k23.xml
+++ b/l10n_se/data/account_chart_template_k23.xml
@@ -1,23 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <odoo>
   <data>
-    <record id="K1_1955_2017" model="account.account.template">
-      <field name="name">Bank transfer</field>
-      <field name="code">1955</field>
-      <field name="user_type_id" ref="account.data_account_type_current_assets"/>
-      <field name="reconcile" eval="True"/>
-    </record>
     <record id="chart_template_K1_2017" model="account.chart.template">
       <field name="name">K1 - Mindre verksamheter</field>
       <field name="parent_id" ref="chart_template_general"/>
-      <field name="transfer_account_id" ref="K1_1955_2017"/>
+      <field name="transfer_account_id" ref="chart1955"/>
       <field name="currency_id" ref="base.SEK"/>
       <field name="cash_account_code_prefix">191</field>
       <field name="bank_account_code_prefix">193</field>
       <field name="code_digits">4</field>
-    </record>
-    <record id="K1_1955_2017" model="account.account.template">
-      <field name="chart_template_id" ref="chart_template_K1_2017"/>
     </record>
     <record id="K1_1010_2017" model="account.account.template">
       <field name="name">Utvecklingsutgifter </field>
@@ -8029,23 +8020,14 @@ skattskyldighet, 25 % moms</field>
       <field name="chart_template_id" ref="chart_template_K1_2017"/>
       <field name="note">Används sällan.</field>
     </record>
-    <record id="K2_1955_2017" model="account.account.template">
-      <field name="name">Bank transfer</field>
-      <field name="code">1955</field>
-      <field name="user_type_id" ref="account.data_account_type_current_assets"/>
-      <field name="reconcile" eval="True"/>
-    </record>
     <record id="chart_template_K2_2017" model="account.chart.template">
       <field name="name">K2 - Små till medelstora verksamheter</field>
       <field name="parent_id" ref="chart_template_general"/>
-      <field name="transfer_account_id" ref="K2_1955_2017"/>
+      <field name="transfer_account_id" ref="chart1955"/>
       <field name="currency_id" ref="base.SEK"/>
       <field name="cash_account_code_prefix">191</field>
       <field name="bank_account_code_prefix">193</field>
       <field name="code_digits">4</field>
-    </record>
-    <record id="K2_1955_2017" model="account.account.template">
-      <field name="chart_template_id" ref="chart_template_K2_2017"/>
     </record>
     <record id="K2_1010_2017" model="account.account.template">
       <field name="name">Utvecklingsutgifter </field>
@@ -16057,23 +16039,14 @@ skattskyldighet, 25 % moms</field>
       <field name="chart_template_id" ref="chart_template_K2_2017"/>
       <field name="note">Används sällan.</field>
     </record>
-    <record id="K3_1955_2017" model="account.account.template">
-      <field name="name">Bank transfer</field>
-      <field name="code">1955</field>
-      <field name="user_type_id" ref="account.data_account_type_current_assets"/>
-      <field name="reconcile" eval="True"/>
-    </record>
     <record id="chart_template_K3_2017" model="account.chart.template">
       <field name="name">K3 - Medelstora till större verksamheter</field>
       <field name="parent_id" ref="chart_template_general"/>
-      <field name="transfer_account_id" ref="K3_1955_2017"/>
+      <field name="transfer_account_id" ref="chart1955"/>
       <field name="currency_id" ref="base.SEK"/>
       <field name="cash_account_code_prefix">191</field>
       <field name="bank_account_code_prefix">193</field>
       <field name="code_digits">4</field>
-    </record>
-    <record id="K3_1955_2017" model="account.account.template">
-      <field name="chart_template_id" ref="chart_template_K3_2017"/>
     </record>
     <record id="K3_1010_2017" model="account.account.template">
       <field name="name">Utvecklingsutgifter </field>
@@ -24085,23 +24058,14 @@ skattskyldighet, 25 % moms</field>
       <field name="chart_template_id" ref="chart_template_K3_2017"/>
       <field name="note">Används sällan.</field>
     </record>
-    <record id="K4_1955_2017" model="account.account.template">
-      <field name="name">Bank transfer</field>
-      <field name="code">1955</field>
-      <field name="user_type_id" ref="account.data_account_type_current_assets"/>
-      <field name="reconcile" eval="True"/>
-    </record>
     <record id="chart_template_K4_2017" model="account.chart.template">
       <field name="name">K4 - större verksamheter / publika företag</field>
       <field name="parent_id" ref="chart_template_general"/>
-      <field name="transfer_account_id" ref="K4_1955_2017"/>
+      <field name="transfer_account_id" ref="chart1955"/>
       <field name="currency_id" ref="base.SEK"/>
       <field name="cash_account_code_prefix">191</field>
       <field name="bank_account_code_prefix">193</field>
       <field name="code_digits">4</field>
-    </record>
-    <record id="K4_1955_2017" model="account.account.template">
-      <field name="chart_template_id" ref="chart_template_K4_2017"/>
     </record>
     <record id="K4_1010_2017" model="account.account.template">
       <field name="name">Utvecklingsutgifter </field>

--- a/l10n_se/data/account_tax_data.xml
+++ b/l10n_se/data/account_tax_data.xml
@@ -3,7 +3,7 @@
   <data>
     <record id="chart1955" model="account.account.template">
       <field name="name">Bank transfer</field>
-      <field name="code">1955general</field>
+      <field name="code">1955</field>
       <field name="user_type_id" ref="account.data_account_type_current_assets"/>
       <field name="reconcile" eval="True"/>
     </record>


### PR DESCRIPTION
..  by making Bank Transfer account common for all CoAs.

If you try to install `l10n_se` in a fresh database, the install fails to the following error:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/odoo/http.py", line 640, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/usr/lib/python2.7/dist-packages/odoo/http.py", line 677, in dispatch
    result = self._call_function(**self.params)
  File "/usr/lib/python2.7/dist-packages/odoo/http.py", line 333, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/odoo/service/model.py", line 101, in wrapper
    return f(dbname, *args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/odoo/http.py", line 326, in checked_call
    result = self.endpoint(*a, **kw)
  File "/usr/lib/python2.7/dist-packages/odoo/http.py", line 935, in __call__
    return self.method(*args, **kw)
  File "/usr/lib/python2.7/dist-packages/odoo/http.py", line 506, in response_wrap
    response = f(*args, **kw)
  File "/usr/lib/python2.7/dist-packages/odoo/addons/web/controllers/main.py", line 889, in call_button
    action = self._call_kw(model, method, args, {})
  File "/usr/lib/python2.7/dist-packages/odoo/addons/web/controllers/main.py", line 877, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/usr/lib/python2.7/dist-packages/odoo/api.py", line 689, in call_kw
    return call_kw_multi(method, model, args, kwargs)
  File "/usr/lib/python2.7/dist-packages/odoo/api.py", line 680, in call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/odoo/addons/base/res/res_config.py", line 128, in action_next
    return self.execute() or self.next()
  File "/usr/lib/python2.7/dist-packages/odoo/addons/account/models/chart_template.py", line 821, in execute
    acc_template_ref, taxes_ref = self.chart_template_id._install_template(company, code_digits=self.code_digits, transfer_account_id=self.transfer_account_id)
  File "/usr/lib/python2.7/dist-packages/odoo/addons/account/models/chart_template.py", line 277, in _install_template
    tmp1, tmp2 = self.parent_id._install_template(company, code_digits=code_digits, transfer_account_id=transfer_account_id, acc_ref=acc_ref, taxes_ref=taxes_ref)
  File "/usr/lib/python2.7/dist-packages/odoo/addons/account/models/chart_template.py", line 280, in _install_template
    tmp1, tmp2 = self._load_template(company, code_digits=code_digits, transfer_account_id=transfer_account_id, account_ref=acc_ref, taxes_ref=taxes_ref)
  File "/usr/lib/python2.7/dist-packages/odoo/addons/account/models/chart_template.py", line 320, in _load_template
    company.transfer_account_id = account_template_ref[transfer_account_id.id]
KeyError: 1244
```

And this is because the child CoAs use a different bank transfer account than the general CoA. There's no differences between the bank transfer accounts among the CoAs so I don't think there's a reason to have one for each child CoA.

I made sure that after making this change the inter-company transfer account is correctly set on the `res.company`.

Hälsningar från Finland,
Miku